### PR TITLE
Fix: Prevent errors on new game startup

### DIFF
--- a/src/RLSettings.lua
+++ b/src/RLSettings.lua
@@ -130,6 +130,12 @@ RLSettings.Button = nil
 
 function RLSettings.loadFromXMLFile()
 
+	-- On a new game the savegame directory is not set on startup 
+	-- As there is no settings file yet either return to prevent errors
+	if g_currentMission == nil or g_currentMission.missionInfo == nil or g_currentMission.missionInfo.savegameDirectory == nil then
+		return
+	end
+
 	local path = g_currentMission.missionInfo.savegameDirectory .. "/rlSettings.xml"
 
 	local xmlFile = XMLFile.loadIfExists("rlSettings", path)

--- a/src/animals/husbandry/RealisticLivestock_AnimalSystem.lua
+++ b/src/animals/husbandry/RealisticLivestock_AnimalSystem.lua
@@ -606,6 +606,12 @@ end
 
 function AnimalSystem:loadFromXMLFile()
 
+	-- On a new game the savegame directory is not set on startup 
+	-- As there is no settings file yet either return to prevent errors
+	if g_currentMission == nil or g_currentMission.missionInfo == nil or g_currentMission.missionInfo.savegameDirectory == nil then
+		return
+	end
+
     local xmlFile = XMLFile.loadIfExists("animalSystem", g_currentMission.missionInfo.savegameDirectory .. "/animalSystem.xml")
 
     if xmlFile == nil then return false end


### PR DESCRIPTION
Checking savegame directory in loadFromXMLFile functions. If no directory just return as there is no file to load either.

Fixes #261